### PR TITLE
Validate positive transaction amounts

### DIFF
--- a/src/main/java/pl/dudios/debtor/transaction/service/TransactionService.java
+++ b/src/main/java/pl/dudios/debtor/transaction/service/TransactionService.java
@@ -36,6 +36,11 @@ public class TransactionService {
         Debt debt = debtRepository.findById(request.debtId())
                 .orElseThrow(() -> new ResourceNotFoundException("Debt with id: " + request.debtId() + " not found"));
 
+        if (request.amount().compareTo(BigDecimal.ZERO) <= 0) {
+            log.error("Transaction amount must be greater than zero");
+            throw new RequestValidationException("Transaction amount must be greater than zero");
+        }
+
         if (request.amount().compareTo(debt.getAmount()) > 0) {
             log.error("Transaction amount is greater than debt amount");
             throw new RequestValidationException("Transaction amount is greater than debt amount");

--- a/src/test/java/pl/dudios/debtor/transaction/service/TransactionServiceTest.java
+++ b/src/test/java/pl/dudios/debtor/transaction/service/TransactionServiceTest.java
@@ -1,0 +1,59 @@
+package pl.dudios.debtor.transaction.service;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import pl.dudios.debtor.debt.model.Debt;
+import pl.dudios.debtor.debt.repo.DebtRepository;
+import pl.dudios.debtor.email.EmailSender;
+import pl.dudios.debtor.exception.RequestValidationException;
+import pl.dudios.debtor.notification.service.NotificationService;
+import pl.dudios.debtor.transaction.controller.TransactionRequest;
+import pl.dudios.debtor.transaction.model.Transaction;
+import pl.dudios.debtor.transaction.repo.TransactionRepository;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+class TransactionServiceTest {
+
+    @InjectMocks
+    private TransactionService underTest;
+    @Mock
+    private TransactionRepository transactionRepository;
+    @Mock
+    private DebtRepository debtRepository;
+    @Mock
+    private NotificationService notificationService;
+    @Mock
+    private EmailSender emailSender;
+
+    @ParameterizedTest
+    @ValueSource(strings = {"0", "-10"})
+    void itShouldThrowWhenAmountIsNotPositive(String amount) {
+        // given
+        TransactionRequest request = new TransactionRequest(1L, new BigDecimal(amount), "desc");
+        Debt debt = Debt.builder().amount(new BigDecimal("100")).build();
+        given(debtRepository.findById(any(Long.class))).willReturn(Optional.of(debt));
+
+        // when
+        assertThatThrownBy(() -> underTest.addTransaction(request))
+                .isInstanceOf(RequestValidationException.class)
+                .hasMessageContaining("greater than zero");
+
+        // then
+        then(transactionRepository).should(never()).save(any(Transaction.class));
+        then(notificationService).shouldHaveNoInteractions();
+        then(emailSender).shouldHaveNoInteractions();
+    }
+}


### PR DESCRIPTION
## Summary
- prevent adding transactions with zero or negative amounts
- cover non-positive amounts with TransactionService unit test

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for pl.dudios:mein-website:3.2.2)*

------
https://chatgpt.com/codex/tasks/task_e_689b06d977b4832da2ee2718bbeae39e